### PR TITLE
Converted python commands to python3 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Project files
+guide.pdf
+
 ## Core latex/pdflatex auxiliary files:
 *.aux
 *.lof

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,234 @@
-.ipynb_checkpoints/
+## Core latex/pdflatex auxiliary files:
 *.aux
+*.lof
 *.log
-guide.out
-guide.pdf
-guide.bbl
-guide.blg
+*.lot
+*.fls
+*.out
+*.toc
+*.fmt
+*.fot
+*.cb
+*.cb2
+.*.lb
+
+## Intermediate documents:
+*.dvi
+*.xdv
+*-converted-to.*
+# these rules might exclude image files for figures etc.
+# *.ps
+# *.eps
+# *.pdf
+
+## Generated if empty string is given at "Please type another file name for output:"
+.pdf
+
+## Bibliography auxiliary files (bibtex/biblatex/biber):
+*.bbl
+*.bcf
+*.blg
+*-blx.aux
+*-blx.bib
+*.run.xml
+
+## Build tool auxiliary files:
+*.fdb_latexmk
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
+*.pdfsync
+
+## Auxiliary and intermediate files from other packages:
+# algorithms
+*.alg
+*.loa
+
+# achemso
+acs-*.bib
+
+# amsthm
+*.thm
+
+# beamer
+*.nav
+*.pre
+*.snm
+*.vrb
+
+# changes
+*.soc
+
+# cprotect
+*.cpt
+
+# elsarticle (documentclass of Elsevier journals)
+*.spl
+
+# endnotes
+*.ent
+
+# fixme
+*.lox
+
+# feynmf/feynmp
+*.mf
+*.mp
+*.t[1-9]
+*.t[1-9][0-9]
+*.tfm
+
+#(r)(e)ledmac/(r)(e)ledpar
+*.end
+*.?end
+*.[1-9]
+*.[1-9][0-9]
+*.[1-9][0-9][0-9]
+*.[1-9]R
+*.[1-9][0-9]R
+*.[1-9][0-9][0-9]R
+*.eledsec[1-9]
+*.eledsec[1-9]R
+*.eledsec[1-9][0-9]
+*.eledsec[1-9][0-9]R
+*.eledsec[1-9][0-9][0-9]
+*.eledsec[1-9][0-9][0-9]R
+
+# glossaries
+*.acn
+*.acr
+*.glg
+*.glo
+*.gls
+*.glsdefs
+
+# gnuplottex
+*-gnuplottex-*
+
+# gregoriotex
+*.gaux
+*.gtex
+
+# htlatex
+*.4ct
+*.4tc
+*.idv
+*.lg
+*.trc
+*.xref
+
+# hyperref
+*.brf
+
+# knitr
+*-concordance.tex
+# TODO Comment the next line if you want to keep your tikz graphics files
+*.tikz
+*-tikzDictionary
+
+# listings
+*.lol
+
+# makeidx
+*.idx
+*.ilg
+*.ind
+*.ist
+
+# minitoc
+*.maf
+*.mlf
+*.mlt
+*.mtc[0-9]*
+*.slf[0-9]*
+*.slt[0-9]*
+*.stc[0-9]*
+
+# minted
+_minted*
+*.pyg
+
+# morewrites
+*.mw
+
+# nomencl
+*.nlo
+
+# pax
+*.pax
+
+# pdfpcnotes
+*.pdfpc
+
+# sagetex
+*.sagetex.sage
+*.sagetex.py
+*.sagetex.scmd
+
+# scrwfile
+*.wrt
+
+# sympy
+*.sout
+*.sympy
+sympy-plots-for-*.tex/
+
+# pdfcomment
+*.upa
+*.upb
+
+# pythontex
+*.pytxcode
+pythontex-files-*/
+
+# thmtools
+*.loe
+
+# TikZ & PGF
+*.dpth
+*.md5
+*.auxlock
+
+# todonotes
+*.tdo
+
+# easy-todo
+*.lod
+
+# xindy
+*.xdy
+
+# xypic precompiled matrices
+*.xyc
+
+# endfloat
+*.ttt
+*.fff
+
+# Latexian
+TSWLatexianTemp*
+
+## Editors:
+# WinEdt
+*.bak
+*.sav
+
+# Texpad
+.texpadtmp
+
+# Kile
+*.backup
+
+# KBibTeX
+*~[0-9]*
+
+# auto folder when using emacs and auctex
+./auto/*
+*.el
+
+# expex forward references with \gathertags
+*-tags.tex
+
+# standalone packages
+*.sta

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,3 @@ clean:
 
 clean-pdfs:
 	-rm -f *.pdf
-
-bak: clean
-	-rm -f tex/*.tex~ *~ *.bak
-	tar zcvf ../phd-thesis-`date '+%Y-%m-%d'`.tgz \
-	    *.sty *.tex *.bst *.pl *.txt *.cfg \
-		Makefile tex/*.tex tex/*.* bib/*.bib imgs/*.pdf imgs/*.png \
-		cd/*.* stuff/*.* 
-

--- a/pages/classification/classification.tex
+++ b/pages/classification/classification.tex
@@ -317,7 +317,7 @@ y_pred_train = mnb.test(scr.train_X,params_nb_sc)
 acc_train = mnb.evaluate(scr.train_y, y_pred_train)
 y_pred_test = mnb.test(scr.test_X,params_nb_sc)
 acc_test = mnb.evaluate(scr.test_y, y_pred_test)
-print("Multinomial Naive Bayes Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test)  )
+print("Multinomial Naive Bayes Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test))
 \end{python}
 
 

--- a/pages/classification/classification.tex
+++ b/pages/classification/classification.tex
@@ -51,7 +51,7 @@ The \textbf{goal of (supervised) machine learning} is to use the training datase
 that maps from $\mathcal{X}$ to $\mathcal{Y}$: this way, given a new instance 
 $x \in \mathcal{X}$ (test example), the machine makes a prediction ${\hat y}$ by evaluating $h$ on $x$, i.e., ${\hat y} = h(x)$. 
 
-%Ana: a imagem seguinte n‹o estava a ser referida em lado nenhum
+%Ana: a imagem seguinte nï¿½o estava a ser referida em lado nenhum
 %\out{
 %\begin{figure}
 %\begin{center}
@@ -224,15 +224,15 @@ P(\mathcal{D}) &=& \prod_{m=1}^M P(x^m,y^m) \nonumber\\
 %gnb = gnbc.GaussianNaiveBayes()
 %params_nb_sd = gnb.train(sd.train_X, sd.train_y)
 %
-%print "Estimated Means"
-%print gnb.means
-%print "Estimated Priors"
-%print gnb.prior
+%print("Estimated Means")
+%print(gnb.means)
+%print("Estimated Priors")
+%print(gnb.prior)
 %y_pred_train = gnb.test(sd.train_X,params_nb_sd)
 %acc_train = gnb.evaluate(sd.train_y, y_pred_train)
 %y_pred_test = gnb.test(sd.test_X,params_nb_sd)
 %acc_test = gnb.evaluate(sd.test_y, y_pred_test)
-%print "Gaussian Naive Bayes Simple Dataset Accuracy train: %f test: %f"%(acc_train,acc_test)
+%print("Gaussian Naive Bayes Simple Dataset Accuracy train: %f test: %f"%(acc_train,acc_test))
 %\end{python}
 %
 %To visualize the surface boundary estimated by na\"ive Bayes, type: 
@@ -317,7 +317,7 @@ y_pred_train = mnb.test(scr.train_X,params_nb_sc)
 acc_train = mnb.evaluate(scr.train_y, y_pred_train)
 y_pred_test = mnb.test(scr.test_X,params_nb_sc)
 acc_test = mnb.evaluate(scr.test_y, y_pred_test)
-print "Multinomial Naive Bayes Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test)  
+print("Multinomial Naive Bayes Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test)  )
 \end{python}
 
 
@@ -506,9 +506,9 @@ described in the following section).
 \footnote{Actually, we are showing a more robust variant of the perceptron, 
 which averages the weight vector as a post-processing step.}  
 
-%% \todo{\small O preceptron algorithm consiste no metodo de gradiente quando a função de custo ´e o erro quadratico, certo? 
+%% \todo{\small O preceptron algorithm consiste no metodo de gradiente quando a funï¿½ï¿½o de custo ï¿½e o erro quadratico, certo? 
 %% Assim, pode ter varios passos (neste caso fixou-se o valor do passo em 1), 
-%% e também tem uma versão bach.}
+%% e tambï¿½m tem uma versï¿½o bach.}
 
 \begin{algorithm}[t]
 
@@ -598,7 +598,7 @@ y_pred_train = perc.test(sd.train_X,params_perc_sd)
 acc_train = perc.evaluate(sd.train_y, y_pred_train)
 y_pred_test = perc.test(sd.test_X,params_perc_sd)
 acc_test = perc.evaluate(sd.test_y, y_pred_test)
-print "Perceptron Simple Dataset Accuracy train: %f test: %f"%(acc_train,acc_test)
+print("Perceptron Simple Dataset Accuracy train: %f test: %f"%(acc_train,acc_test))
 \end{python}
 
 \item Plot the decision boundary found:
@@ -723,7 +723,7 @@ y_pred_train = mira.test(sd.train_X,params_mira_sd)
 acc_train = mira.evaluate(sd.train_y, y_pred_train)
 y_pred_test = mira.test(sd.test_X,params_mira_sd)
 acc_test = mira.evaluate(sd.test_y, y_pred_test)
-print "Mira Simple Dataset Accuracy train: %f test: %f"%(acc_train,acc_test)
+print("Mira Simple Dataset Accuracy train: %f test: %f"%(acc_train,acc_test))
 fig,axis = sd.add_line(fig,axis,params_mira_sd,"Mira","green")
 
 params_mira_sc = mira.train(scr.train_X,scr.train_y)
@@ -731,7 +731,7 @@ y_pred_train = mira.test(scr.train_X,params_mira_sc)
 acc_train = mira.evaluate(scr.train_y, y_pred_train)
 y_pred_test = mira.test(scr.test_X,params_mira_sc)
 acc_test = mira.evaluate(scr.test_y, y_pred_test)
-print "Mira Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test)
+print("Mira Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test))
 \end{python}
   
 Compare the
@@ -929,7 +929,7 @@ y_pred_train = me_lbfgs.test(sd.train_X,params_meb_sd)
 acc_train = me_lbfgs.evaluate(sd.train_y, y_pred_train)
 y_pred_test = me_lbfgs.test(sd.test_X,params_meb_sd)
 acc_test = me_lbfgs.evaluate(sd.test_y, y_pred_test)
-print "Max-Ent batch Simple Dataset Accuracy train: %f test: %f"%(acc_train,acc_test)
+print("Max-Ent batch Simple Dataset Accuracy train: %f test: %f"%(acc_train,acc_test))
 
 fig,axis = sd.add_line(fig,axis,params_meb_sd,"Max-Ent-Batch","orange")
 \end{python}
@@ -942,7 +942,7 @@ y_pred_train = me_lbfgs.test(scr.train_X,params_meb_sc)
 acc_train = me_lbfgs.evaluate(scr.train_y, y_pred_train)
 y_pred_test = me_lbfgs.test(scr.test_X,params_meb_sc)
 acc_test = me_lbfgs.evaluate(scr.test_y, y_pred_test)
-print "Max-Ent Batch Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test)
+print("Max-Ent Batch Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test))
 \end{python}
 
 \item Now, fix $\lambda = 1.0$ and train with SGD (you might try to adjust the initial step). 
@@ -957,7 +957,7 @@ y_pred_train = me_sgd.test(scr.train_X,params_meo_sc)
 acc_train = me_sgd.evaluate(scr.train_y, y_pred_train)
 y_pred_test = me_sgd.test(scr.test_X,params_meo_sc)
 acc_test = me_sgd.evaluate(scr.test_y, y_pred_test)
-print "Max-Ent Online Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test)
+print("Max-Ent Online Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test))
 \end{python}
 \end{enumerate}
 \end{exercise}
@@ -1081,7 +1081,7 @@ y_pred_train = svm.test(sd.train_X,params_svm_sd)
 acc_train = svm.evaluate(sd.train_y, y_pred_train)
 y_pred_test = svm.test(sd.test_X,params_svm_sd)
 acc_test = svm.evaluate(sd.test_y, y_pred_test)
-print "SVM Online Simple Dataset Accuracy train: %f test: %f"%(acc_train,acc_test)
+print("SVM Online Simple Dataset Accuracy train: %f test: %f"%(acc_train,acc_test))
 
 fig,axis = sd.add_line(fig,axis,params_svm_sd,"SVM","orange")
 
@@ -1090,7 +1090,7 @@ y_pred_train = svm.test(scr.train_X,params_svm_sc)
 acc_train = svm.evaluate(scr.train_y, y_pred_train)
 y_pred_test = svm.test(scr.test_X,params_svm_sc)
 acc_test = svm.evaluate(scr.test_y, y_pred_test)
-print "SVM Online Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test)
+print("SVM Online Amazon Sentiment Accuracy train: %f test: %f"%(acc_train,acc_test))
 \end{python}
   
 Compare the

--- a/pages/intro/la.tex
+++ b/pages/intro/la.tex
@@ -50,7 +50,7 @@ import numpy as np
 m = 3
 n = 2
 a = np.zeros([m,n])
-print a 
+print(a)
 [[ 0.  0.]
  [ 0.  0.]
  [ 0.  0.]]
@@ -58,16 +58,16 @@ print a
 
 \noindent You can check the shape and the data type of your array using the following commands:
 \begin{python}
-print a.shape
+print(a.shape)
 (3, 2)
-print a.dtype.name
+print(a.dtype.name)
 float64
 \end{python}
 This shows you that ``a'' is an 3*2 array of type float64. By default, arrays contain 64~bit\footnotemark\footnotetext{On your computer, particularly if you have an older computer, \code{int} might denote 32~bits integers} floating point numbers. You can specify the particular array type by using the keyword dtype.
 
 \begin{python}
 a = np.zeros([m,n],dtype=int)
-print a.dtype
+print(a.dtype)
 int64
 \end{python}
 
@@ -76,7 +76,7 @@ int64
 \noindent You can also create arrays from lists of numbers:
 \begin{python}
 a = np.array([[2,3],[3,4]])
-print a
+print(a)
 [[2 3]
  [3 4]]
 \end{python}
@@ -102,18 +102,18 @@ b = np.array([[1,1],[1,1]])
 a_dim1, a_dim2 = a.shape
 b_dim1, b_dim2 = b.shape
 c = np.zeros([a_dim1,b_dim2])
-for i in xrange(a_dim1):
-   for j in xrange(b_dim2):
-       for k in xrange(a_dim2):
+for i in range(a_dim1):
+   for j in range(b_dim2):
+       for k in range(a_dim2):
           c[i,j] += a[i,k]*b[k,j]
-print c
+print(c)
 \end{python}
 
 This is, however, cumbersome and inefficient. Numpy supports matrix multiplication with the dot function:
 
 \begin{python}
 d = np.dot(a,b)
-print d
+print(d)
 \end{python}
 
 \textbf{Important note:} with numpy, you must use \code{dot} to get matrix multiplication, the expression {a * b} denotes element-wise multiplication.
@@ -180,8 +180,8 @@ It has the property that for all $\textbf{A} \in \mathbb{R}^{n \times n}$, $\tex
 I = np.eye(2)
 x = np.array([2.3, 3.4])
 
-print I
-print np.dot(I,x)
+print(I)
+print(np.dot(I,x))
 
 [[ 1.,  0.],
  [ 0.,  1.]]
@@ -201,7 +201,7 @@ In numpy, you can access the transpose of a matrix as the \code{T} attribute:
 
 \begin{python}
 A = np.array([ [1, 2], [3, 4] ])
-print A.T
+print(A.T)
 \end{python}
 
 \item A square matrix $\textbf{A} \in \mathbb{R}^{n\times n}$ is {\bf symmetric} if  $\textbf{A}=\textbf{A}^{T}$.

--- a/pages/intro/no.tex
+++ b/pages/intro/no.tex
@@ -208,7 +208,7 @@ def gradient_descent(start_x,func,grad):
     max_iter = 100
     x_new = start_x
     res = []
-    for i in xrange(max_iter):
+    for i in range(max_iter):
         x_old = x_new
         #Use beta egual to -1 for gradient descent 
         x_new = x_old - step_size * grad(x_new)
@@ -216,9 +216,9 @@ def gradient_descent(start_x,func,grad):
         f_x_old = func(x_old)
         res.append([x_new,f_x_new])
         if(abs(f_x_new - f_x_old) < prec):
-            print "change in function values too small, leaving"
+            print("change in function values too small, leaving")
             return np.array(res)
-    print "exceeded maximum number of iterations, leaving"
+    print("exceeded maximum number of iterations, leaving")
     return np.array(res)
 \end{python}
 

--- a/pages/intro/python.tex
+++ b/pages/intro/python.tex
@@ -28,7 +28,7 @@ main ways in which you can run code in Python:
 program in it, using your IDE of choosing e.g. PyCharm:
 
 \begin{python}
-print 'Hello World!'
+print('Hello World!')
 \end{python}
 
 After saving and closing the file, you can run your code by using the run
@@ -47,7 +47,7 @@ chosing e.g. Jupyter-notebook. There, you can run Python code
 by simply writing it and pressing enter (ctr+enter in Jupyter).
 
 \begin{python}
- In[]: print "Hello, World!"
+ In[]: print("Hello, World!")
 Out[]: Hello, World!
 \end{python}
 
@@ -84,14 +84,14 @@ well documented. Numpy and matplotlib are pleasant exceptions;
 
 Python supports all basic arithmetic operations, including exponentiation. For
 example, the following code: \begin{python}
-print 3 + 5
-print 3 - 5
-print 3 * 5
-print 3 / 5
-print 3 ** 5
+print(3 + 5)
+print(3 - 5)
+print(3 * 5)
+print(3 / 5)
+print(3 ** 5)
 \end{python}
 
-\noindent will produce the following output:
+\noindent will produce the following output in python 2:
 \begin{python}
 8
 -2
@@ -100,12 +100,14 @@ print 3 ** 5
 243
 \end{python}
 
-Notice that division is always considered as integer division, hence the result
-being 0 on the example above. To force a floating point division you can force
+Notice that in Python 2 division is always considered as integer division, hence the result
+being 0 on the example above. To force a floating point division in python 2 you can force
 one of the operands to be a floating point number: \begin{python}
-print 3 / 5.0
+print(3 / 5.0)
 0.6
 \end{python}
+
+For python 3, the division is considered float point, so the operation (3 / 5) or (3 / 5.0) is always 0.6. 
 
 Also, notice that the symbol \texttt{**} is used as exponentation operator, unlike other major languages which use the symbol \texttt{\^}. In fact, the \texttt{\^} symbol has a different meaning in Python (bitwise XOR) so, in the beginning, be sure to double-check your code if it uses exponentiation and it is giving unexpected results.
 
@@ -143,13 +145,13 @@ the even numbers from 2 to 8.
 \begin{python}
 i = 2
 while i < 10:
-  print i  
+  print(i)
   i += 2 
 \end{python}
 
 \begin{python}
 for i in range(2,10,2):
-    print i
+    print(i)
 \end{python}
 
 You can copy and run this Jupyter. Alternatively you can write this into your
@@ -165,7 +167,7 @@ consider the following code:
 \begin{python}
 a=1
 while a <= 3:
-    print a
+    print(a)
     a += 1
 \end{python}
 
@@ -184,7 +186,7 @@ Can you then predict the output of the following code?:
 \begin{python}
 a=1
 while a <= 3:
-    print a
+    print(a)
 a += 1
 \end{python}
 
@@ -199,11 +201,11 @@ The \code{if} statement allows to control the flow of your program. The next pro
 \begin{python}
 hour = 16
 if hour < 12:
-    print 'Good morning!'
+    print('Good morning!')
 elif hour >= 12 and hour < 20:
-    print 'Good afternoon!'
+    print('Good afternoon!')
 else:
-    print 'Good evening!'
+    print('Good evening!')
 \end{python}
 
 \subsubsection{Functions}
@@ -214,11 +216,11 @@ The following is a function in Python.
 \begin{python}
 def greet(hour):
     if hour < 12:
-        print 'Good morning!'
+        print('Good morning!')
     elif hour >= 12 and hour < 20:
-        print 'Good afternoon!'
+        print('Good afternoon!')
     else:
-        print 'Good evening!'
+        print('Good evening!')
 \end{python}
 
 You can write this command into Jupyter directly or write them into a file and run the file in Jupyter. Once you do this the function will be available for you to use. Call the function \code{greet} with different hours of the day (for example, type \texttt{greet(16)}) and see that the program will greet you accordingly.
@@ -269,15 +271,15 @@ An alternative to IDEs, that can also be useful for quick debugging in Jupyter, 
 \begin{python}
 def greet(hour):
     if hour < 12:
-        print 'Good morning!'
+        print('Good morning!')
     elif hour >= 12 and hour < 20:
-        print 'Good afternoon!'
+        print('Good afternoon!')
     else:
         import pdb; pdb.set_trace()
-        print 'Good evening!'
+        print('Good evening!')
 \end{python}
 
-Load the new definition of the function by writing this code in a file or a Jupyter cell and running it. Now, if you try \texttt{greet(50)} the code execution should stop at the place where you located the break-point (that is, in the \texttt{print 'Good evening!'} statement). You can now run new commands or inspect variables. For this purpose there are a number of commands you can use\footnotemark\footnotetext{The complete list can be found at \url{http://docs.python.org/library/pdb.html}}, but we provide here a short table with the most useful: 
+Load the new definition of the function by writing this code in a file or a Jupyter cell and running it. Now, if you try \texttt{greet(50)} the code execution should stop at the place where you located the break-point (that is, in the \texttt{print('Good evening!')} statement). You can now run new commands or inspect variables. For this purpose there are a number of commands you can use\footnotemark\footnotetext{The complete list can be found at \url{http://docs.python.org/library/pdb.html}}, but we provide here a short table with the most useful: 
 
 \begin{table}[!h]
 \begin{center}
@@ -315,7 +317,7 @@ stopped at
 pdb> n
 > ./lxmls-toolkit/yourfile.py(8)greet()
       7                 import pdb; pdb.set_trace()
-----> 8                 print 'Good evening!' 
+----> 8                 print('Good evening!') 
 \end{python}
 
 \noindent Now we can inspect the variable \texttt{hour} using the p(retty)p(rint) option
@@ -359,10 +361,10 @@ the hour is less than 0 or more than 24.  \end{exercise}
 \begin{python}
 while True:
     try:
-        x = int(raw_input("Please enter a number: "))
+        x = int(input("Please enter a number: "))
         break
     except ValueError:
-        print "Oops! That was no valid number. Try again..."
+        print("Oops! That was no valid number. Try again...")
 \end{python}
 
 It works by first executing the \textit{try} clause. If no exception occurs, the \textit{except} clause is skipped; if an exception does occur, and if its type matches the exception named in the \textit{except} keyword, the except clause is executed; otherwise, the exception is raised and execution is aborted (if it is not caught by outer \textit{try} statements).
@@ -400,7 +402,7 @@ my_tools.py
 
 \begin{python}
 def my_print(input):
-    print input
+    print(input)
 \end{python}
 
 From Jupyter you can now import and use this tool as
@@ -550,11 +552,11 @@ import numpy as np
 A = np.arange(100)
 
 # These two lines do exactly the same thing
-print np.mean(A)
-print A.mean()
+print(np.mean(A))
+print(A.mean())
 
 C = np.cos(A)
-print C.ptp()
+print(C.ptp())
 \end{python}
 
 \begin{exercise}

--- a/pages/seq_discriminative/seq_discriminative.tex
+++ b/pages/seq_discriminative/seq_discriminative.tex
@@ -385,7 +385,7 @@ import lxmls.readers.pos_corpus as pcc
 import lxmls.sequences.id_feature as idfc
 import lxmls.sequences.extended_feature as exfc
 
-print "CRF Exercise"
+print("CRF Exercise")
 
 corpus = pcc.PostagCorpus()
 train_seq = corpus.read_sequence_list_conll("data/train-02-21.conll",max_sent_len=10,max_nr_sent=1000)
@@ -434,7 +434,7 @@ eval_train = crf_online.evaluate_corpus(train_seq, pred_train)
 eval_dev = crf_online.evaluate_corpus(dev_seq, pred_dev)
 eval_test = crf_online.evaluate_corpus(test_seq, pred_test)
 
-print "CRF - ID Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test)
+print("CRF - ID Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test))
 \end{python}
 
 You should get values similar to these:
@@ -492,7 +492,7 @@ eval_train = crf_online.evaluate_corpus(train_seq, pred_train)
 eval_dev = crf_online.evaluate_corpus(dev_seq, pred_dev)
 eval_test = crf_online.evaluate_corpus(test_seq, pred_test)
 
-print "CRF - Extended Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test)
+print("CRF - Extended Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test))
 \end{python}
 
 You should get values close to the following:
@@ -607,7 +607,7 @@ Here is the code for the simple feature set:
 feature_mapper = idfc.IDFeatures(train_seq)
 feature_mapper.build_features()
 
-print "Perceptron Exercise"
+print("Perceptron Exercise")
 
 sp = spc.StructuredPerceptron(corpus.word_dict, corpus.tag_dict, feature_mapper)
 sp.num_epochs = 20
@@ -644,7 +644,7 @@ eval_train = sp.evaluate_corpus(train_seq, pred_train)
 eval_dev = sp.evaluate_corpus(dev_seq, pred_dev)
 eval_test = sp.evaluate_corpus(test_seq, pred_test)
 
-print "Structured Perceptron - ID Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test)
+print("Structured Perceptron - ID Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test))
 \end{python}
 
 
@@ -690,7 +690,7 @@ eval_train = sp.evaluate_corpus(train_seq, pred_train)
 eval_dev = sp.evaluate_corpus(dev_seq, pred_dev)
 eval_test = sp.evaluate_corpus(test_seq, pred_test)
 
-print "Structured Perceptron - Extended Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test)
+print("Structured Perceptron - Extended Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test))
 \end{python}
 
 And here are the expected results:
@@ -715,7 +715,7 @@ Structured Perceptron - Extended Features Accuracy Train: 0.984 Dev: 0.888 Test:
 %import sequences.extended_feature as exfc
 %
 %
-%print "Perceptron Exercise"
+%print("Perceptron Exercise")
 %corpus = pcc.PostagCorpus()
 %train_seq = corpus.read_sequence_list_conll("../data/train-02-21.conll",max_sent_len=10,max_nr_sent=1000)
 %test_seq = corpus.read_sequence_list_conll("../data/test-23.conll",max_sent_len=10,max_nr_sent=1000)
@@ -740,7 +740,7 @@ Structured Perceptron - Extended Features Accuracy Train: 0.984 Dev: 0.888 Test:
 %eval_dev = sp.evaluate_corpus(dev_seq.seq_list,pred_dev)
 %eval_test = sp.evaluate_corpus(test_seq.seq_list,pred_test)
 %
-%print "Structured Percetron - ID Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test)
+%print("Structured Percetron - ID Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test))
 %\end{python}
 %
 %You should get values similar to these:
@@ -777,7 +777,7 @@ Structured Perceptron - Extended Features Accuracy Train: 0.984 Dev: 0.888 Test:
 %eval_dev = sp.evaluate_corpus(dev_seq.seq_list,pred_dev)
 %eval_test = sp.evaluate_corpus(test_seq.seq_list,pred_test)
 %
-%print "Structured Percetron - Extended Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test)
+%print("Structured Percetron - Extended Features Accuracy Train: %.3f Dev: %.3f Test: %.3f"%(eval_train,eval_dev,eval_test))
 %
 %\end{python}
 %

--- a/pages/sequences/decoding.tex
+++ b/pages/sequences/decoding.tex
@@ -172,11 +172,11 @@ Use the given function \emph{compute\_scores} on the first training sequence and
 
 \begin{python}
 initial_scores, transition_scores, final_scores, emission_scores = hmm.compute_scores(simple.train.seq_list[0])
-print initial_scores
+print(initial_scores)
 
 [-0.40546511 -1.09861229]
 
-print transition_scores
+print(transition_scores)
 
 [[[-0.69314718        -inf]
   [-0.69314718 -0.47000363]]
@@ -187,11 +187,11 @@ print transition_scores
  [[-0.69314718        -inf]
   [-0.69314718 -0.47000363]]]
 
-print final_scores
+print(final_scores)
 
 [       -inf -0.98082925]
 
-print emission_scores
+print(emission_scores)
 
 [[-0.28768207 -1.38629436]
  [-0.28768207 -1.38629436]
@@ -442,7 +442,7 @@ P(X=x) = \mathrm{backward}(0, \text{\tt start}).
 \subsection*{The forward backward algorithm}
 
 We have seen how we can compute the probability of a sequence $x$ using the the forward and backward probabilities by computing  $\mathrm{forward}(N+1, \text{\tt stop})$ and $ \mathrm{backward}(0, \text{\tt start})$ respectively. Moreover,  the probability of a sequence $x$ can be computed with both forward and backward probabilities at a particular position $i$. The probability of a  given sequence $x$ at any position $i$ in the sequence can be computed
-as follows \footnote{ The second equality in \ref{eq::fbsanity} can be justified as follows. Since $Y_i=y_i$ is observed then  $X_{i+1}, \dots, X_{N}$ is conditionally independent from any $X_k$ for $k \leq i$ . Therefore  $P(x_1,\dots, x_N, y_i) =  P( x_{i+1},\dots, x_N Ê| yi , x_1, \dots,x_i ) \cdot P( yi , x_1, \dots,x_i ) =  P( x_{i+1},\dots, x_N Ê| yi  ) \cdot P( yi , x_1, \dots,x_i ) = backward(i,y_i) \cdot forward(i,y_i)$.}:
+as follows \footnote{ The second equality in \ref{eq::fbsanity} can be justified as follows. Since $Y_i=y_i$ is observed then  $X_{i+1}, \dots, X_{N}$ is conditionally independent from any $X_k$ for $k \leq i$ . Therefore  $P(x_1,\dots, x_N, y_i) =  P( x_{i+1},\dots, x_N ï¿½| yi , x_1, \dots,x_i ) \cdot P( yi , x_1, \dots,x_i ) =  P( x_{i+1},\dots, x_N ï¿½| yi  ) \cdot P( yi , x_1, \dots,x_i ) = backward(i,y_i) \cdot forward(i,y_i)$.}:
 
 
 \begin{eqnarray}
@@ -537,12 +537,12 @@ passes give the same log-likelihood.
 %sure your implementation is correct: 
 \begin{python}
 log_likelihood, forward = hmm.decoder.run_forward(initial_scores, transition_scores, final_scores, emission_scores)
-print 'Log-Likelihood =', log_likelihood
+print('Log-Likelihood =', log_likelihood)
 
 Log-Likelihood = -5.06823232601
 
 log_likelihood, backward = hmm.decoder.run_backward(initial_scores, transition_scores, final_scores, emission_scores)
-print 'Log-Likelihood =', log_likelihood
+print('Log-Likelihood =', log_likelihood)
 
 Log-Likelihood = -5.06823232601
 \end{python}
@@ -647,7 +647,7 @@ state_posteriors, _, _ = hmm.compute_posteriors(initial_scores,
                                                 transition_scores,
                                                 final_scores,
                                                 emission_scores)
-print state_posteriors
+print(state_posteriors)
 
 [[ 0.95738152  0.04261848]
  [ 0.75281282  0.24718718]
@@ -660,11 +660,11 @@ print state_posteriors
 Run the posterior decode on the first test sequence, and evaluate it.
 \begin{python}
 y_pred = hmm.posterior_decode(simple.test.seq_list[0])
-print "Prediction test 0:", y_pred
+print("Prediction test 0:", y_pred)
 
 walk/rainy walk/rainy shop/sunny clean/sunny
 
-print "Truth test 0:", simple.test.seq_list[0]
+print("Truth test 0:", simple.test.seq_list[0])
 
 walk/rainy walk/sunny shop/sunny clean/sunny 
 \end{python}
@@ -672,11 +672,11 @@ walk/rainy walk/sunny shop/sunny clean/sunny
 Do the same for the second test sequence:
 \begin{python}
 y_pred = hmm.posterior_decode(simple.test.seq_list[1])
-print "Prediction test 1:", y_pred
+print("Prediction test 1:", y_pred)
 
 clean/rainy walk/rainy tennis/rainy walk/rainy 
 
-print "Truth test 1:", simple.test.seq_list[1]
+print("Truth test 1:", simple.test.seq_list[1])
 
 clean/sunny walk/sunny tennis/sunny walk/sunny 
 \end{python}
@@ -698,20 +698,20 @@ Try, for example, adding 0.1 to all the counts, and repeating this exercise with
 \begin{python}
 hmm.train_supervised(simple.train, smoothing=0.1)
 y_pred = hmm.posterior_decode(simple.test.seq_list[0])
-print "Prediction test 0 with smoothing:", y_pred
+print("Prediction test 0 with smoothing:", y_pred)
 
 walk/rainy walk/rainy shop/sunny clean/sunny 
 
-print "Truth test 0:", simple.test.seq_list[0]
+print("Truth test 0:", simple.test.seq_list[0])
 
 walk/rainy walk/sunny shop/sunny clean/sunny
 
 y_pred = hmm.posterior_decode(simple.test.seq_list[1])
-print "Prediction test 1 with smoothing:", y_pred
+print("Prediction test 1 with smoothing:", y_pred)
 
 clean/sunny walk/sunny tennis/sunny walk/sunny 
 
-print "Truth test 1:", simple.test.seq_list[1]
+print("Truth test 1:", simple.test.seq_list[1])
 
 clean/sunny walk/sunny tennis/sunny walk/sunny 
 \end{python}
@@ -881,20 +881,20 @@ the ones given.
 \begin{python}
 hmm.train_supervised(simple.train, smoothing=0.1)
 y_pred, score = hmm.viterbi_decode(simple.test.seq_list[0])
-print "Viterbi decoding Prediction test 0 with smoothing:", y_pred, score
+print("Viterbi decoding Prediction test 0 with smoothing:", y_pred, score)
 
 walk/rainy walk/rainy shop/sunny clean/sunny  -6.02050124698
 
-print "Truth test 0:", simple.test.seq_list[0]
+print("Truth test 0:", simple.test.seq_list[0])
 
 walk/rainy walk/sunny shop/sunny clean/sunny 
 
 y_pred, score = hmm.viterbi_decode(simple.test.seq_list[1])
-print "Viterbi decoding Prediction test 1 with smoothing:", y_pred, score
+print("Viterbi decoding Prediction test 1 with smoothing:", y_pred, score)
 
 clean/sunny walk/sunny tennis/sunny walk/sunny  -11.713974074
 
-print "Truth test 1:", simple.test.seq_list[1]
+print("Truth test 1:", simple.test.seq_list[1])
 
 clean/sunny walk/sunny tennis/sunny walk/sunny 
 \end{python}

--- a/pages/sequences/em.tex
+++ b/pages/sequences/em.tex
@@ -210,9 +210,9 @@ EM algorithm. Look at the code for EM algorithm in file
 
         if evaluate:
             acc = self.evaluate_EM(dataset)
-            print "Initial accuracy: %f"%(acc)
+            print("Initial accuracy: %f"%(acc))
             
-        for t in xrange(1, num_epochs):
+        for t in range(1, num_epochs):
             #E-Step
             total_log_likelihood = 0.0
             self.clear_counts(smoothing)
@@ -229,13 +229,13 @@ EM algorithm. Look at the code for EM algorithm in file
 
                 self.update_counts(sequence, state_posteriors, transition_posteriors)
                 total_log_likelihood += log_likelihood
-            print "Iter: %i Log Likelihood: %f"%(t, total_log_likelihood)
+            print("Iter: %i Log Likelihood: %f"%(t, total_log_likelihood))
             #M-Step
             self.compute_parameters()
             if evaluate:
                  ### Evaluate accuracy at this iteration
                 acc = self.evaluate_EM(dataset)
-                print "Iter: %i Accuracy: %f"%(t,acc)
+                print("Iter: %i Accuracy: %f"%(t,acc))
 \end{python}
 
 \end{exercise}

--- a/pages/sequences/hmm.tex
+++ b/pages/sequences/hmm.tex
@@ -110,32 +110,32 @@ at the training and test set.
 \begin{python}
 import lxmls.readers.simple_sequence as ssr
 simple = ssr.SimpleSequence()
-print simple.train
+print(simple.train)
 
 [walk/rainy walk/sunny shop/sunny clean/sunny , walk/rainy walk/rainy shop/rainy clean/sunny , walk/sunny shop/sunny shop/sunny clean/sunny ]
 
-print simple.test
+print(simple.test)
 
 [walk/rainy walk/sunny shop/sunny clean/sunny , clean/sunny walk/sunny tennis/sunny walk/sunny ]
 \end{python}
 Get in touch with the classes used to store the sequences, you will need this for the next exercise. Note that each label is internally stored as a number. This number can be used as index of an array to store information regarding that label.
 \begin{python}
 for sequence in simple.train.seq_list:
-    print sequence
+    print(sequence)
 
 walk/rainy walk/sunny shop/sunny clean/sunny
 walk/rainy walk/rainy shop/rainy clean/sunny
 walk/sunny shop/sunny shop/sunny clean/sunny
 
 for sequence in simple.train.seq_list:
-    print sequence.x
+    print(sequence.x)
 
 [0, 0, 1, 2]
 [0, 0, 1, 2]
 [0, 1, 1, 2]
 
 for sequence in simple.train.seq_list:
-    print sequence.y
+    print(sequence.y)
 
 [0, 1, 1, 1]
 [0, 0, 0, 1]

--- a/pages/sequences/ml.tex
+++ b/pages/sequences/ml.tex
@@ -160,20 +160,20 @@ Run this function given the simple dataset above and look at the estimated proba
 import lxmls.sequences.hmm as hmmc
 hmm = hmmc.HMM(simple.x_dict, simple.y_dict)
 hmm.train_supervised(simple.train)
-print "Initial Probabilities:", hmm.initial_probs
+print("Initial Probabilities:", hmm.initial_probs)
 
 [ 0.66666667  0.33333333]
 
-print "Transition Probabilities:", hmm.transition_probs
+print("Transition Probabilities:", hmm.transition_probs)
 
 [[ 0.5    0.   ]
  [ 0.5    0.625]]
 
-print "Final Probabilities:", hmm.final_probs
+print("Final Probabilities:", hmm.final_probs)
 
 [ 0.     0.375]
 
-print "Emission Probabilities", hmm.emission_probs
+print("Emission Probabilities", hmm.emission_probs)
 
 [[ 0.75   0.25 ]
  [ 0.25   0.375]


### PR DESCRIPTION
This is a simple translation from python2 commands to python3 without any rewrite in the guide text. The text should be revised later. 

obs: Some files were with latin1 characters. My editor by default saved them with utf8.