### PR TITLE
Restore changes from pull request #124 lost during manual merge #125

### DIFF
--- a/pages/reinforcement_learning/reinforcement_learning.tex
+++ b/pages/reinforcement_learning/reinforcement_learning.tex
@@ -83,7 +83,13 @@ The \textbf{state-value function} $v_{\pi}(s)$ of an MDP is the expected return 
 \label{fig:MDP}
 \end{figure}
 
-Consider the (simplified) MDP represented in Figure \ref{fig:MDP}: it consists of three states (1, 2, and 3) that are connected by three actions (move to state 1, 2, or 3) that determine state transitions (our MDP is thus actually a Markov Reward Process (MRP) with deterministic state transitions). The rewards are 10.0, 2.0, and 3.0 for a transition into state 1, 2, and 3, respectively. 
+Consider the (simplified) MDP represented in Figure \ref{fig:MDP}: it consists of three states (1, 2, and 3) that are connected by three actions (move to state 1, 2, or 3) that determine state transitions (our MDP is thus actually a Markov Reward Process (MRP) with deterministic state transitions). The rewards $\mathcal{R}_s^a$ are 1.5, -1.8333\dots and 19.8333\dots for a transition into state 1, 2, and 3, respectively. So, in our example $\mathcal{R}_s^a$ depends only on action (i.e. destination state) but it doesn't depend on source state.
+
+Such reward values are chosen to get nice expected values of the next reward given policy $\pi$:
+\begin{align*}
+    {\mathcal{R}}^{\pi}(s) & = \sum_{a \in \mathcal{A}} \pi(a|s) \mathcal{R}_s^a
+\end{align*}
+For the policy we will use below expected values of the next reward ${\mathcal{R}}^{\pi}(s)$ are 10.0, 2.0, and 3.0 for state 1, 2, and 3, respectively.
 
 Given full information about states and rewards, we want to evaluate a given policy. A central tool is the \textbf{Bellman Expectation Equation}, which tells us how to decompose the state-value function into immediate reward plus discounted value of successor state s.t.
 \begin{align*}


### PR DESCRIPTION
These changes were accidentally lost because there was a conflict
between two updates in the same paragraph:

(1) Minor text improvements (from PR #125)
(2) Fixing description of rewards (from PR #124)

Change (2) was lost during manual merge.
This commit restores it. Change (1) is also preserved.