### PR TITLE
Updated logsumexp import for NumpyLogLinear exercise

### DIFF
--- a/pages/deep_learning/deep_learning_ff.tex
+++ b/pages/deep_learning/deep_learning_ff.tex
@@ -295,9 +295,8 @@ data = AmazonData(corpus=corpus)
 \end{python}
 Compare the following numpy implementation of a log-linear model with the derivations seen in the previous sections. Introduce comments on the blocks marked with \# relating them to the corresponding algorithm steps.
 \begin{python}
-from lxmls.deep_learning.utils import Model, glorot_weight_init, index2onehot
+from lxmls.deep_learning.utils import Model, glorot_weight_init, index2onehot, logsumexp
 import numpy as np
-from scipy.misc import logsumexp
 
 class NumpyLogLinear(Model):
 


### PR DESCRIPTION
Updated logsumexp import for NumpyLogLinear exercise

The example in the guide was not in sync with the code in the
master/student branches. The guide was importing the logsumexp
function from scipy, while the code version uses the LxMLS version
of logsumexp. The latter is the expected behavior, so this commit 
updates the guide version.