### PR TITLE
Minor typo and removed unicode

### DIFF
--- a/pages/sequences/decoding.tex
+++ b/pages/sequences/decoding.tex
@@ -442,7 +442,7 @@ P(X=x) = \mathrm{backward}(0, \text{\tt start}).
 \subsection*{The forward backward algorithm}
 
 We have seen how we can compute the probability of a sequence $x$ using the the forward and backward probabilities by computing  $\mathrm{forward}(N+1, \text{\tt stop})$ and $ \mathrm{backward}(0, \text{\tt start})$ respectively. Moreover,  the probability of a sequence $x$ can be computed with both forward and backward probabilities at a particular position $i$. The probability of a  given sequence $x$ at any position $i$ in the sequence can be computed
-as follows \footnote{ The second equality in \ref{eq::fbsanity} can be justified as follows. Since $Y_i=y_i$ is observed then  $X_{i+1}, \dots, X_{N}$ is conditionally independent from any $X_k$ for $k \leq i$ . Therefore  $P(x_1,\dots, x_N, y_i) =  P( x_{i+1},\dots, x_N �| yi , x_1, \dots,x_i ) \cdot P( yi , x_1, \dots,x_i ) =  P( x_{i+1},\dots, x_N �| yi  ) \cdot P( yi , x_1, \dots,x_i ) = backward(i,y_i) \cdot forward(i,y_i)$.}:
+as follows \footnote{ The second equality in \ref{eq::fbsanity} can be justified as follows. Since $Y_i=y_i$ is observed then  $X_{i+1}, \dots, X_{N}$ is conditionally independent from any $X_k$ for $k \leq i$ . Therefore  $P(x_1,\dots, x_N, y_i) =  P( x_{i+1},\dots, x_N | y_i , x_1, \dots,x_i ) \cdot P( y_i , x_1, \dots,x_i ) =  P( x_{i+1},\dots, x_N | y_i  ) \cdot P( y_i , x_1, \dots,x_i ) = backward(i,y_i) \cdot forward(i,y_i)$.}:
 
 
 \begin{eqnarray}


### PR DESCRIPTION
1. Removed unicode characters that produced the following error during compilation:
```
! Package inputenc Error: Unicode character � (U+FFFD)
(inputenc)                not set up for use with LaTeX.
```
2. Fixed typo in formula. There were indices that should have been subscript and were not