### PR TITLE
Removing remmanents of Python 2

### DIFF
--- a/pages/sequences/pos-induction.tex
+++ b/pages/sequences/pos-induction.tex
@@ -67,7 +67,7 @@ Iter: 19 Accuracy: 0.385409
 confusion_matrix = cm.build_confusion_matrix(test_seq.seq_list, viterbi_pred_test, 
                                              len(corpus.tag_dict), hmm.get_num_states())
 cm.plot_confusion_bar_graph(confusion_matrix, corpus.tag_dict, 
-                            xrange(hmm.get_num_states()), 'Confusion matrix')
+                            range(hmm.get_num_states()), 'Confusion matrix')
 \end{python}
 Note: your results may not be the same as in this example since we are using a random start, but the trend should be the same, 
 with log-likelihood increasing at every iteration. 

--- a/pages/sequences/pos.tex
+++ b/pages/sequences/pos.tex
@@ -54,14 +54,14 @@ viterbi_pred_train = hmm.viterbi_decode_corpus(train_seq)
 posterior_pred_train = hmm.posterior_decode_corpus(train_seq)
 eval_viterbi_train =   hmm.evaluate_corpus(train_seq, viterbi_pred_train)
 eval_posterior_train =  hmm.evaluate_corpus(train_seq, posterior_pred_train)
-print "Train Set Accuracy: Posterior Decode %.3f, Viterbi Decode: %.3f"%(eval_posterior_train,eval_viterbi_train)
+print("Train Set Accuracy: Posterior Decode %.3f, Viterbi Decode: %.3f"%(eval_posterior_train,eval_viterbi_train))
 Train Set Accuracy: Posterior Decode 0.985, Viterbi Decode: 0.985
 
 viterbi_pred_test = hmm.viterbi_decode_corpus(test_seq)
 posterior_pred_test = hmm.posterior_decode_corpus(test_seq)
 eval_viterbi_test =   hmm.evaluate_corpus(test_seq,viterbi_pred_test)
 eval_posterior_test = hmm.evaluate_corpus(test_seq,posterior_pred_test)
-print "Test Set Accuracy: Posterior Decode %.3f, Viterbi Decode: %.3f"%(eval_posterior_test,eval_viterbi_test)
+print("Test Set Accuracy: Posterior Decode %.3f, Viterbi Decode: %.3f"%(eval_posterior_test,eval_viterbi_test))
 Test Set Accuracy: Posterior Decode 0.350, Viterbi Decode: 0.509
 \end{python}
 What do you observe? Remake the previous exercise but now train the HMM
@@ -87,7 +87,7 @@ viterbi_pred_test = hmm.viterbi_decode_corpus(test_seq)
 posterior_pred_test = hmm.posterior_decode_corpus(test_seq)
 eval_viterbi_test =   hmm.evaluate_corpus(test_seq, viterbi_pred_test)
 eval_posterior_test = hmm.evaluate_corpus(test_seq, posterior_pred_test)
-print "Best Smoothing %f --  Test Set Accuracy: Posterior Decode %.3f, Viterbi Decode: %.3f"%(best_smoothing,eval_posterior_test,eval_viterbi_test)
+print("Best Smoothing %f --  Test Set Accuracy: Posterior Decode %.3f, Viterbi Decode: %.3f"%(best_smoothing,eval_posterior_test,eval_viterbi_test))
 
 Best Smoothing 0.100000 --  Test Set Accuracy: Posterior Decode 0.837, Viterbi Decode: 0.827
 \end{python}
@@ -101,7 +101,7 @@ predicted tags). You should get something like what is shown in Figure~\ref{fig:
 import lxmls.sequences.confusion_matrix as cm
 import matplotlib.pyplot as plt
 confusion_matrix = cm.build_confusion_matrix(test_seq.seq_list, viterbi_pred_test, len(corpus.tag_dict), hmm.get_num_states())
-cm.plot_confusion_bar_graph(confusion_matrix, corpus.tag_dict, xrange(hmm.get_num_states()), 'Confusion matrix')
+cm.plot_confusion_bar_graph(confusion_matrix, corpus.tag_dict, range(hmm.get_num_states()), 'Confusion matrix')
 plt.show()
 \end{python}
 

--- a/pages/unsupervised/em.tex
+++ b/pages/unsupervised/em.tex
@@ -181,7 +181,7 @@ EM algorithm. Look at the code for EM algorithm in file
             ### Evaluate accuracy at initial iteration
             pred = self.model.viterbi_decode_corpus(seq_list.seq_list)
             acc = self.model.evaluate_corpus(seq_list.seq_list,pred)
-        for t in xrange(1,nr_iter):
+        for t in range(1,nr_iter):
             #E-Step
             total_likelihood = 0
             self.model.clear_counts(smoothing)
@@ -189,7 +189,7 @@ EM algorithm. Look at the code for EM algorithm in file
                 posteriors,likelihood = self.model.get_posteriors(seq)
                 self.model.update_counts(seq,posteriors)
                 total_likelihood += likelihood
-            print "Iter: %i - Log Likelihood %f"%(t,-1*math.log(total_likelihood))
+            print("Iter: %i - Log Likelihood %f"%(t,-1*math.log(total_likelihood)))
             #M-Step
             self.model.update_params()
 
@@ -197,7 +197,7 @@ EM algorithm. Look at the code for EM algorithm in file
                  ### Evaluate accuracy at this iteration
                 pred = self.model.viterbi_decode_corpus(seq_list.seq_list)
                 acc = self.model.evaluate_corpus(seq_list.seq_list,pred)
-                print "Iter: %i acc %f"%(t,acc)
+                print("Iter: %i acc %f"%(t,acc))
 \end{python}
 
 \end{exercise}


### PR DESCRIPTION
Changed all examples of xrange by range and added parenthesis to all examples of print without them.

There is still three instances of xrange in "pages/sequences/decoding.tex" but they are commented, so I decided not to change them.

Solves #143 