### PR TITLE
Fix dimensions of `log_tilde_z` in `deep_learning_ff.tex`

### DIFF
--- a/pages/deep_learning/deep_learning_ff.tex
+++ b/pages/deep_learning/deep_learning_ff.tex
@@ -316,7 +316,7 @@ class NumpyLogLinear(Model):
         z = np.dot(input, self.weight.T) + self.bias
 
         # Softmax implemented in log domain
-        log_tilde_z = z - logsumexp(z, axis=1, keepdims=True)[:, None]
+        log_tilde_z = z - logsumexp(z, axis=1, keepdims=True)
 
         return log_tilde_z
 


### PR DESCRIPTION
Dear all,

Thank you for this guide.

This PR fixes the dimensions of `log_tilde_z`. This is according to the up-to-date code in the toolkit repository.